### PR TITLE
Add resize callback

### DIFF
--- a/src/scripts/h5p-dictation-sentence.js
+++ b/src/scripts/h5p-dictation-sentence.js
@@ -36,6 +36,7 @@ class Sentence {
     this.params.callbacks = this.params.callbacks || {};
     this.params.callbacks.playAudio = this.params.callbacks.playAudio || (() => {});
     this.params.callbacks.onInteracted = this.params.callbacks.onInteracted || (() => {});
+    this.params.callbacks.resize = this.params.callbacks.resize || (() => {});
 
     this.solutionText = Util.htmlDecode(params.sentence.text).trim();
     this.solutionText = (!params.ignorePunctuation) ? this.solutionText : Sentence.stripPunctuation(this.solutionText);

--- a/src/scripts/h5p-dictation.js
+++ b/src/scripts/h5p-dictation.js
@@ -159,6 +159,9 @@ class Dictation extends H5P.Question {
             },
             onInteracted: () => {
               this.handleInteracted();
+            },
+            resize: () => {
+              this.trigger('resize');
             }
           }
         },


### PR DESCRIPTION
H5P content types inherit the `trigger` function from H5P.EventDispatcher() via H5P.ContentType. That function can be used to dispatch messages to the core of H5P (and also to the host platform if required, e.g. for xAPI statements). Using `resize` as the value of the first argument of that function informs H5P core that the iframe should be resized to fit the content.

I've created a callback function that can be used in the Sentences class (will clean up the code involved later - this looks ugly :-))